### PR TITLE
Specify proper size not to send frames larger than standard MTU (1500-Byte)

### DIFF
--- a/board/RFSoC4x2/base/notebooks/board/CMAC_Intro.ipynb
+++ b/board/RFSoC4x2/base/notebooks/board/CMAC_Intro.ipynb
@@ -167,8 +167,8 @@
    "source": [
     "from pynq import allocate\n",
     "\n",
-    "dma_buf_in = allocate(packets_in.shape[0])\n",
-    "dma_buf_out = allocate(packets_in.shape[0])\n",
+    "dma_buf_in = allocate(packets_in.shape[0], dtype=np.uint8)\n",
+    "dma_buf_out = allocate(packets_in.shape[0], dtype=np.uint8)\n",
     "dma_buf_in[:] = packets_in"
    ]
   },


### PR DESCRIPTION
The current notebook could be use to send packets to a NIC, however the transfer buffers is 4 times larger than needed as the default size is 4-Byte for element. However, for ASCII character we only need 1-Byte.

This is not a big deal in loopback. However, the frame ends being larger than 1500-Byte, which is the standard MTU size in Linux. Thus, the OS drops the frame, unless the MTU is changed.  