### PR TITLE
XRT package renaming, PYNQv3.0 update

### DIFF
--- a/boards/RFSoC2x2/RFSoC2x2.spec
+++ b/boards/RFSoC2x2/RFSoC2x2.spec
@@ -6,6 +6,6 @@ BSP_RFSoC2x2 :=
 BITSTREAM_RFSoC2x2 := base/base.bit
 FPGA_MANAGER_RFSoC2x2 := 1
 
-STAGE4_PACKAGES_RFSoC2x2 := pynq xrt_zocl usbgadget ethernet smbus2
+STAGE4_PACKAGES_RFSoC2x2 := pynq xrt usbgadget ethernet smbus2
 STAGE4_PACKAGES_RFSoC2x2 += sensorconf boot_leds
 STAGE4_PACKAGES_RFSoC2x2 += xrfclk xrfdc xsdfec rfsystem rfsoc_sam

--- a/boards/RFSoC4x2/RFSoC4x2.spec
+++ b/boards/RFSoC4x2/RFSoC4x2.spec
@@ -6,7 +6,7 @@ BSP_RFSoC4x2 := RFSoC4x2.bsp
 BITSTREAM_RFSoC4x2 := 
 FPGA_MANAGER_RFSoC4x2 := 1
 
-STAGE4_PACKAGES_RFSoC4x2 := pynq xrt_zocl usbgadget ethernet smbus2 
+STAGE4_PACKAGES_RFSoC4x2 := pynq xrt usbgadget ethernet smbus2 
 STAGE4_PACKAGES_RFSoC4x2 += sensorconf boot_rfsoc4x2
 STAGE4_PACKAGES_RFSoC4x2 += xrfclk xrfdc xsdfec rfsystem
 STAGE4_PACKAGES_RFSoC4x2 += tics rfsoc4x2_oled rfsoc_sam

--- a/boards/ZCU111/ZCU111.spec
+++ b/boards/ZCU111/ZCU111.spec
@@ -5,4 +5,4 @@ ARCH_ZCU111 := aarch64
 BSP_ZCU111 := ZCU111.bsp
 
 STAGE4_PACKAGES_ZCU111 := xrfclk xrfdc xsdfec ethernet zcu111_sensors
-STAGE4_PACKAGES_ZCU111 += xrt_zocl 
+STAGE4_PACKAGES_ZCU111 += xrt 

--- a/boards/ZCU208/ZCU208.spec
+++ b/boards/ZCU208/ZCU208.spec
@@ -4,5 +4,5 @@
 ARCH_ZCU208 := aarch64
 BSP_ZCU208 := ZCU208.bsp
 
-STAGE4_PACKAGES_ZCU208 := pynq ethernet xrt_zocl xrfclk xrfdc xsdfec
+STAGE4_PACKAGES_ZCU208 := pynq ethernet xrt xrfclk xrfdc xsdfec
 STAGE4_PACKAGES_ZCU208 += smbus2 rfsystem tics


### PR DESCRIPTION
* XRT package match renaming of xrt_zocl --> xrt
* bump pynq submodule to pynq image_v3.0 HEAD at Xilinx/PYNQ@b8ddb4264b79756d81f76a2bb8e06a5ad5aef262